### PR TITLE
Small improvement

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ func main() {
 			cmd.Help()
 		},
 	}
+	rootCmd.PersistentFlags().BoolVarP(&logg.ShowDebug, "debug", "d", false, "Enable debug log")
+
 	applycmd.AddCommandTo(rootCmd)
 	convertcmd.AddCommandTo(rootCmd)
 

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -83,7 +83,15 @@ func (ringRules RingRules) CalculateChanges(ring builderfile.RingInfo, ringFilen
 	}
 
 	var discoveredDisks, commandQueue []string
-	for zoneID, zoneRules := range ringRules.Zones {
+
+	var zoneIDs []uint64
+	for zoneID := range ringRules.Zones {
+		zoneIDs = append(zoneIDs, zoneID)
+	}
+	sort.Slice(zoneIDs, func(i, j int) bool { return zoneIDs[i] < zoneIDs[j] }) // for reproducibility in tests
+
+	for _, zoneID := range zoneIDs {
+		zoneRules := ringRules.Zones[zoneID]
 		var nodeIPs []string
 		for nodeIP := range zoneRules.Nodes {
 			nodeIPs = append(nodeIPs, nodeIP)


### PR DESCRIPTION
During playing around with the artisan, I stumbled about the following and tried to fix it:

* command line switch to enable debug logs
* support full path for builder file: `swift-ring-artisan apply -b /path/to/<ring>.builder`
* error out if <rule.yaml> file misses key for `<ring>.builder`
* stable iteration through zones for reproducibility in tests