### PR TITLE
improved overload factor handling

### DIFF
--- a/pkg/builderfile/builderfile.go
+++ b/pkg/builderfile/builderfile.go
@@ -86,6 +86,7 @@ func File(builderFilename string) RingInfo {
 	ringParsed.ReassignedCooldown = 0
 	ringParsed.ReassignedRemaining = time.Time{}
 	ringParsed.Zones = 0
+	ringParsed.OverloadFactorPercent = 0 // rely on OverloadFactorDecimal
 
 	sort.Slice(ringParsed.Devices, func(i, j int) bool {
 		return ringParsed.Devices[i].ID < ringParsed.Devices[j].ID

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -87,8 +87,9 @@ func (ringRules RingRules) CalculateChanges(ring builderfile.RingInfo, ringFilen
 
 	var discoveredDisks, commandQueue []string
 
-	if ring.OverloadFactorDecimal != ringRules.Overload {
-		logg.Debug("Overload does not match, adding command to change it")
+	// Special handling for floating point comparison
+	if diff := math.Abs(ring.OverloadFactorDecimal - ringRules.Overload); diff > 0.000001 {
+		logg.Debug("Overload does not match, adding command to change it from %f to %f", ring.OverloadFactorDecimal, ringRules.Overload)
 		commandQueue = append(commandQueue, ring.CommandSetOverload(ringFilename, ringRules.Overload))
 	}
 


### PR DESCRIPTION
* better floating point comparison
* Ignoring field OverloadFactorPercent in swift-ring-builder output comparison with pickle file - only OverloadFactorDecimal can be retrieved from PickleData