### PR TITLE
fix: Update parsePickle.go

### DIFF
--- a/pkg/builderfile/parsePickle.go
+++ b/pkg/builderfile/parsePickle.go
@@ -25,16 +25,16 @@ type pickleData struct {
 	Overload   float64
 }
 
-func unmarshal(input interface{}) pickleData {
+func unmarshal(input any) pickleData {
 	var mappedData pickleData
 	must.Succeed(mapstructure.Decode(guessType(input), &mappedData))
 	return mappedData
 }
 
-func guessType(input interface{}) interface{} {
+func guessType(input any) any {
 	switch v := input.(type) {
 	case *types.Dict:
-		data := make(map[string]interface{})
+		data := make(map[string]any)
 		for _, entry := range *v {
 			key := entry.Key.(string)
 			// skip keys which have tuple indexed Dicts
@@ -61,7 +61,7 @@ func guessType(input interface{}) interface{} {
 		}
 		return data
 	case *types.List:
-		var data []interface{}
+		var data []any
 		for _, entry := range *v {
 			// skip empty entries in Devices so that mapstructure does not convert them to empty DeviceInfos
 			if entry == nil {
@@ -83,7 +83,7 @@ type Array types.List
 
 var _ types.Callable = &Array{}
 
-func (*Array) Call(args ...interface{}) (interface{}, error) {
+func (*Array) Call(args ...any) (any, error) {
 	// TODO: make fully functional
 	// args[0] contains a type like B or H which is not taken into account
 	return args[1].(*types.List), nil
@@ -96,7 +96,7 @@ func decodeBuilderFile(builderFilename string) pickleData {
 	}
 	defer builderReader.Close()
 	u := pickle.NewUnpickler(builderReader)
-	u.FindClass = func(module, name string) (interface{}, error) {
+	u.FindClass = func(module, name string) (any, error) {
 		if module == "array" && name == "array" {
 			return &Array{}, nil
 		}


### PR DESCRIPTION
>> modernize
/tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:28:22: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:34:22: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:34:35: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:37:27: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:64:14: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:86:28: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:86:42: interface{} can be replaced by any /tmp/build/f541ec31/swift-ring-artisan/pkg/builderfile/parsePickle.go:99:43: interface{} can be replaced by any make: *** [Makefile:90: run-modernize] Error 3